### PR TITLE
breaking change: .open is now .openPort, and .close is now .closePort

### DIFF
--- a/examples/01-basics/sketch.js
+++ b/examples/01-basics/sketch.js
@@ -1,11 +1,20 @@
+let exampleName = '01-basics';
+
 // declare a variable for p5.SerialPort object
 let serial;
 
 // declare variable for latest data
-let latestData = "waiting for data";
+let latestData = 'waiting for data';
+
+let yellow;
 
 function setup() {
-  createCanvas(windowWidth, windowHeight);
+  // small canvas
+  createCanvas(500, 500);
+
+  textAlign(CENTER, CENTER);
+
+  yellow = color(255, 255, 0);
 
   // instantiate the SerialPort objects
   serial = new p5.SerialPort();
@@ -14,65 +23,61 @@ function setup() {
   // You should have a callback defined to see the results
   serial.list();
 
-  // Assuming our Arduino is connected, let's open the connection to it
-  // Change this to the name of your arduino's serial port
-  serial.open("/dev/tty.usbmodem141101");
+  // // Assuming our Arduino is connected, let's open the connection to it
+  // // Change this to the name of your arduino's serial port
+  // serial.open('/dev/tty.usbmodem141101');
 
-  // Here are the callbacks that you can register
-  // When we connect to the underlying server
-  serial.on("connected", serverConnected);
+  // // Here are the callbacks that you can register
+  // // When we connect to the underlying server
+  // serial.on('connected', serverConnected);
 
-  // When we get a list of serial ports that are available
-  serial.on("list", gotList);
-  // OR
-  //serial.onList(gotList);
+  // // When we get a list of serial ports that are available
+  serial.on('list', gotList);
 
-  // When we some data from the serial port
-  serial.on("data", gotData);
-  // OR
-  //serial.onData(gotData);
+  // // When we some data from the serial port
+  // serial.on('data', gotData);
+  // // OR
+  // //serial.onData(gotData);
 
-  // When or if we get an error
-  serial.on("error", gotError);
-  // OR
-  //serial.onError(gotError);
+  // // When or if we get an error
+  // serial.on('error', gotError);
+  // // OR
+  // //serial.onError(gotError);
 
   // When our serial port is opened and ready for read/write
-  serial.on("open", gotOpen);
-  // OR
-  //serial.onOpen(gotOpen);
+  serial.on('open', gotOpen);
 
-  serial.on("close", gotClose);
+  // serial.on('close', gotClose);
 
-  // Callback to get the raw data, as it comes in for handling yourself
-  //serial.on('rawdata', gotRawData);
-  // OR
-  //serial.onRawData(gotRawData);
+  // // Callback to get the raw data, as it comes in for handling yourself
+  // //serial.on('rawdata', gotRawData);
+  // // OR
+  // //serial.onRawData(gotRawData);
 }
 
 // We are connected and ready to go
 function serverConnected() {
-  print("Connected to Server");
+  print('Connected to Server');
 }
 
 // Got the list of ports
 function gotList(thelist) {
-  print("List of Serial Ports:");
+  print('List of Serial Ports:');
   // theList is an array of their names
   for (let i = 0; i < thelist.length; i++) {
     // Display in the console
-    print(i + " " + thelist[i]);
+    print(i + ' ' + thelist[i]);
   }
 }
 
 // Connected to our serial device
 function gotOpen() {
-  print("Serial Port is Open");
+  print('Serial Port is Open');
 }
 
 function gotClose() {
-  print("Serial Port is Closed");
-  latestData = "Serial Port is Closed";
+  print('Serial Port is Closed');
+  latestData = 'Serial Port is Closed';
 }
 
 // Ut oh, here is an error, let's log it
@@ -96,13 +101,15 @@ function gotData() {
 
 // We got raw from the serial port
 function gotRawData(thedata) {
-  print("gotRawData" + thedata);
+  print('gotRawData' + thedata);
 }
 
 function draw() {
-  background(255, 255, 255);
-  fill(0, 0, 0);
-  text(latestData, 10, 10);
+  background(yellow);
+  text(exampleName, width / 2, height / 10);
+  print('test');
+  // fill(0, 0, 0);
+  // text(latestData, 10, 10);
   // Polling method
   /*
   if (serial.available() > 0) {

--- a/lib/p5.serialport.js
+++ b/lib/p5.serialport.js
@@ -39,7 +39,7 @@
    *	function setup() {
    *		 createCanvas(400, 300);
    *		 serial = new p5.SerialPort()
-   *		 serial.open(portName);
+   *		 serial.openPort(portName);
    *	}
    */
   p5.SerialPort = function (_hostname, _serverport) {
@@ -102,8 +102,8 @@
       if (typeof messageObject.method !== 'undefined') {
         if (messageObject.method == 'echo') {
         } else if (messageObject.method === 'openserial') {
-          if (typeof self.openCallback !== 'undefined') {
-            self.openCallback();
+          if (typeof self.openPortCallback !== 'undefined') {
+            self.openPortCallback();
           }
         } else if (messageObject.method === 'data') {
           // Add to buffer, assuming this comes in byte by byte
@@ -123,8 +123,8 @@
             self.listCallback(messageObject.data);
           }
         } else if (messageObject.method === 'close') {
-          if (typeof self.closeCallback !== 'undefined') {
-            self.closeCallback();
+          if (typeof self.closePortCallback !== 'undefined') {
+            self.closePortCallback();
           }
         } else if (messageObject.method === 'write') {
           // Success Callback?
@@ -143,8 +143,8 @@
     };
 
     this.socket.onclose = function (event) {
-      if (typeof self.closeCallback !== 'undefined') {
-        self.closeCallback();
+      if (typeof self.closePortCallback !== 'undefined') {
+        self.closePortCallback();
       }
     };
 
@@ -183,7 +183,7 @@
    * 		function setup() {
    * 			createCanvas(400, 300);
    *	 		serial = new p5.SerialPort();
-   *	 		serial.open(portName);
+   *	 		serial.openPort(portName);
    *	 		println(serial.isConnected());
    * 		}
    */
@@ -208,7 +208,7 @@
    * 		createCanvas(windowWidth, windowHeight);
    * 		serial = new p5.SerialPort();
    * 		serial.list();
-   * 		serial.open("/dev/cu.usbmodem1411");
+   * 		serial.openPort("/dev/cu.usbmodem1411");
    * 		}
    *
    * For full example: <a href="https://itp.nyu.edu/physcomp/labs/labs-serial-communication/two-way-duplex-serial-communication-using-p5js/">Link</a>
@@ -237,26 +237,26 @@
    * Opens the serial port to enable data flow.
    * Use the {[serialOptions]} parameter to set the baudrate if it's different from the p5 default, 9600.
    *
-   * @method open
+   * @method openPort
    * @param  {String} serialPort Name of the serial port, something like '/dev/cu.usbmodem1411'
    * @param  {Object} [serialOptions] Object with optional options as {key: value} pairs.
    *                                Options include 'baudrate'.
    * @param  {Function} [serialCallback] Callback function when open completes
    * @example
    * 		// Change this to the name of your arduino's serial port
-   * 		serial.open("/dev/cu.usbmodem1411");
+   * 		serial.openPort("/dev/cu.usbmodem1411");
    *
    * @example
    * 		// All of the following are valid:
-   *		serial.open(portName);
-   *		serial.open(portName, {}, onOpen);
-   *		serial.open(portName, {baudrate: 9600}, onOpen)
+   *		serial.openPort(portName);
+   *		serial.openPort(portName, {}, onOpen);
+   *		serial.openPort(portName, {baudrate: 9600}, onOpen)
    *
    *		function onOpen() {
    *		  print('opened the serial port!');
    *		}
    */
-  p5.SerialPort.prototype.open = function (
+  p5.SerialPort.prototype.openPort = function (
     _serialport,
     _serialoptions,
     cb,
@@ -640,8 +640,8 @@
    *		let inData;
    *
    *		function setup() {
-   *		  serial.open(portOpen);
-   *		  serial.close(portClose);
+   *		  serial.openPort(portOpen);
+   *		  serial.closePort(portClose);
    *		}
    *
    *  	function portOpen() {
@@ -652,10 +652,10 @@
    *		  println('The serial port closed.');
    *		}
    */
-  p5.SerialPort.prototype.close = function (cb) {
+  p5.SerialPort.prototype.closePort = function (cb) {
     //
     if (typeof cb === 'function') {
-      this.closeCallback = cb;
+      this.closePortCallback = cb;
     }
     this.emit({
       method: 'close',
@@ -747,11 +747,11 @@
   // Version 2
   p5.SerialPort.prototype.on = function (_event, _callback) {
     if (_event == 'open') {
-      this.openCallback = _callback;
+      this.openPortCallback = _callback;
     } else if (_event == 'data') {
       this.dataCallback = _callback;
     } else if (_event == 'close') {
-      this.closeCallback = _callback;
+      this.closePortCallback = _callback;
     } else if (_event == 'error') {
       this.errorCallback = _callback;
     } else if (_event == 'list') {


### PR DESCRIPTION
this was made to fix a warning on the console when using this library with the latest p5.js.

the p5.js Friendly Error System (FES) was complaining that this library had a conflict with the reserved keywords "open" and "close", this change now fixes that, yay.